### PR TITLE
Add dynamic day prompt

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -122,7 +122,8 @@ function App(): React.JSX.Element {
           style={{
             backgroundColor: isDarkMode ? Colors.black : Colors.white,
           }}>
-          <XForm date = {currentDate} 
+          <XForm date = {currentDate}
+            prevDays = {previousDays}
             clear = {clear} resetClear = {resetClear}
             refresh = {refresh} resetRefresh = {resetRefresh}
             update = {update} resetUpdate = {resetUpdate}/>

--- a/Form_Components/Describe_Part.js
+++ b/Form_Components/Describe_Part.js
@@ -20,7 +20,7 @@ function Describe(props)  {
         title ={props.title}
         description={props.description}
         setDescription={props.setDescription}
-        placeholder = {`How was your ${props.title}`}
+        placeholder = {props.placeholder ? props.placeholder : `How was your ${props.title}`}
         />
       </View>
     )

--- a/Form_Components/Form.js
+++ b/Form_Components/Form.js
@@ -183,10 +183,18 @@ function XForm(props) {
     }
   }, [props.update])
 
+  let dayPlaceholder = 'How was the day been?';
+  if (props.prevDays && props.prevDays.length > 0) {
+    const diff = props.prevDays[0].prevDayCount;
+    if (diff > 1) {
+      dayPlaceholder = `How has the last ${diff} days been?`;
+    }
+  }
+
   return (
     <View style ={styles.container}>
-      
-      <Describe title='Day' description={day} setDescription={setDay} height={130}/>
+
+      <Describe title='Day' description={day} setDescription={setDay} height={130} placeholder={dayPlaceholder}/>
       <Describe title='Health' description={heal} setDescription={setHeal} height={90}/>
       <ChecksThanks 
         title='Appreciations' count={3}


### PR DESCRIPTION
## Summary
- allow passing placeholder prop to Describe component
- adjust day field placeholder based on days since last entry
- pass previous days information to form

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6841bd7ecbd0832a9cf36be82e0c79d7