### PR TITLE
Add 3D word chart

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,8 @@ import {
   StyleSheet,
   useColorScheme,
   View,
+  Text,
+  TouchableOpacity,
 } from 'react-native';
 
 import {
@@ -24,6 +26,8 @@ import {
 import XHeader from './Top_Components/xHeader';
 import XForm from './Form_Components/Form';
 import NotifyDay from './Notify_Components/Notify';
+import WordFreq3DChart from './Top_Components/WordFreq3DChart';
+import { getMathWordCounts } from './Form_Components/Store_Form';
 
 type SectionProps = PropsWithChildren<{
   title: string;
@@ -72,6 +76,8 @@ function App(): React.JSX.Element {
   const [refresh, setRefresh] = useState(false);
   const [update, setUpdate] = useState(false);
   const [clear, setClear] = useState(false);
+  const [showChart, setShowChart] = useState(false);
+  const [wordCounts, setWordCounts] = useState({});
 
   const handleRefresh = () => {
     setRefresh(true);  // Trigger refresh
@@ -93,6 +99,20 @@ function App(): React.JSX.Element {
     setClear(true);  // Trigger Clear
   };
 
+  const handleChart = async () => {
+    try {
+      const counts = await getMathWordCounts();
+      setWordCounts(counts);
+      setShowChart(true);
+    } catch (e) {
+      console.error('Error getting word counts', e);
+    }
+  };
+
+  const closeChart = () => {
+    setShowChart(false);
+  };
+
   const resetClear = () => {
     setClear(false);  // Trigger Clear
   };
@@ -103,7 +123,7 @@ function App(): React.JSX.Element {
 
   return (
     <SafeAreaView style={backgroundStyle}>
-      <NotifyDay 
+      <NotifyDay
         prevDays={previousDays}
         setPrevDays={setPreviousDays}
         date = {currentDate} />
@@ -114,20 +134,34 @@ function App(): React.JSX.Element {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         style={backgroundStyle}>
-        <XHeader date = {currentDate} 
+        <XHeader date = {currentDate}
         handleClear = {handleClear}
         handleRefresh = {handleRefresh}
-        handleUpdate = {handleUpdate}/>
-        <View
-          style={{
-            backgroundColor: isDarkMode ? Colors.black : Colors.white,
-          }}>
-          <XForm date = {currentDate}
-            prevDays = {previousDays}
-            clear = {clear} resetClear = {resetClear}
-            refresh = {refresh} resetRefresh = {resetRefresh}
-            update = {update} resetUpdate = {resetUpdate}/>
-        </View>
+        handleUpdate = {handleUpdate}
+        handleChart = {handleChart}/>
+        {showChart ? (
+          <View style={{height:400}}>
+            <WordFreq3DChart wordCounts={wordCounts} />
+            <View style={{alignItems:'center', marginTop:10}}>
+              <TouchableOpacity onPress={closeChart} style={{padding:10, borderWidth:1}}>
+                <View>
+                  <Text style={{color:'white'}}>Close</Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ) : (
+          <View
+            style={{
+              backgroundColor: isDarkMode ? Colors.black : Colors.white,
+            }}>
+            <XForm date = {currentDate}
+              prevDays = {previousDays}
+              clear = {clear} resetClear = {resetClear}
+              refresh = {refresh} resetRefresh = {resetRefresh}
+              update = {update} resetUpdate = {resetUpdate}/>
+          </View>
+        )}
       </ScrollView>
     </SafeAreaView>
   );

--- a/Form_Components/Store_Form.js
+++ b/Form_Components/Store_Form.js
@@ -280,6 +280,33 @@ function getList(type, tableName, input){
   })
 }
 
+function getMathWordCounts(){
+  return new Promise((resolve, reject) => {
+    db.transaction(tx => {
+      tx.executeSql(
+        'SELECT mathAdd, mathSubtract, mathMultiply, mathDivide FROM entries',
+        [],
+        (tx, results) => {
+          const counts = {};
+          for (let i = 0; i < results.rows.length; i++) {
+            const row = results.rows.item(i);
+            ['mathAdd','mathSubtract','mathMultiply','mathDivide'].forEach(col => {
+              const word = row[col];
+              if (word && word.trim() !== '') {
+                counts[word] = (counts[word] || 0) + 1;
+              }
+            });
+          }
+          resolve(counts);
+        },
+        error => {
+          reject(error);
+        }
+      );
+    });
+  });
+}
+
 function createDateFromString(dateString){
   // Split the string into day, month, year parts
   const [year, month, day] = dateString.split('-');
@@ -487,4 +514,4 @@ function updateForm(entry){
   );
 }
 
-export {storeForm, updateForm, getThanks, getTasks, resetStorage, getPrevDays, getList};
+export {storeForm, updateForm, getThanks, getTasks, resetStorage, getPrevDays, getList, getMathWordCounts};

--- a/README.md
+++ b/README.md
@@ -77,3 +77,19 @@ To learn more about React Native, take a look at the following resources:
 - [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
 - [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
 - [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+
+## Word Frequency 3‑D Chart
+
+This project includes an optional visualization that shows the frequency of each
+entered math word as floating 3‑D blocks. The chart uses the
+`react-native-threejs` and `three` libraries. Install dependencies and run the
+app as usual:
+
+```bash
+npm install
+```
+
+To open the chart, use the **Word Chart** option in the top drop‑down menu. A
+scene will appear with blocks sized according to the number of times each word
+has been used in previous entries.
+

--- a/Top_Components/WordFreq3DChart.js
+++ b/Top_Components/WordFreq3DChart.js
@@ -1,0 +1,52 @@
+import React, { useRef, useEffect } from 'react';
+import { View } from 'react-native';
+import { GLView } from 'react-native-threejs';
+import { Renderer } from 'react-native-threejs';
+import * as THREE from 'three';
+
+const WordFreq3DChart = ({ wordCounts }) => {
+  const onContextCreate = async gl => {
+    const { drawingBufferWidth: width, drawingBufferHeight: height } = gl;
+    const renderer = new Renderer({ gl });
+    renderer.setSize(width, height);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+    camera.position.z = 10;
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(0, 0, 10);
+    scene.add(light);
+
+    const entries = Object.entries(wordCounts || {});
+
+    entries.forEach(([word, count], index) => {
+      const geometry = new THREE.BoxGeometry(1, 1, 1);
+      const material = new THREE.MeshPhongMaterial({ color: 0x2194ce });
+      const cube = new THREE.Mesh(geometry, material);
+      cube.position.x = (index - entries.length / 2) * 2;
+      const scale = 0.5 + count * 0.5;
+      cube.scale.set(scale, scale, scale);
+      cube.userData = { word };
+      scene.add(cube);
+    });
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+      scene.children.forEach(child => {
+        if (child instanceof THREE.Mesh) {
+          child.rotation.x += 0.01;
+          child.rotation.y += 0.01;
+        }
+      });
+      renderer.render(scene, camera);
+      gl.endFrameEXP();
+    };
+    animate();
+  };
+
+  return <GLView style={{ flex: 1 }} onContextCreate={onContextCreate} />;
+};
+
+export default WordFreq3DChart;
+

--- a/Top_Components/xDropDown.js
+++ b/Top_Components/xDropDown.js
@@ -6,12 +6,13 @@ import {
     TouchableOpacity
   } from 'react-native';
 
-  const XDropDown = ({handleClear, handleRefresh, handleUpdate}) => {
+  const XDropDown = ({handleClear, handleRefresh, handleUpdate, handleChart}) => {
     return (
       <View style={{zIndex:2, position:'absolute', top:50, backgroundColor:'black'}}>
         <XDropDownItem name = 'Update' onPress = {handleUpdate}/>
         <XDropDownItem name = 'Clear' onPress = {handleClear}/>
         <XDropDownItem name = 'Refresh' onPress = {handleRefresh}/>
+        <XDropDownItem name = 'Word Chart' onPress = {handleChart}/>
         <XDropDownItem name = 'Settings'/>
       </View>
     );

--- a/Top_Components/xHeader.js
+++ b/Top_Components/xHeader.js
@@ -14,7 +14,7 @@ import {
 
   import XDropDown from './xDropDown';
 
-  const XHeader = ({date, handleClear, handleRefresh, handleUpdate}) => {
+  const XHeader = ({date, handleClear, handleRefresh, handleUpdate, handleChart}) => {
     const [showDropDown, setShowDropDown] = useState(false)
 
     const toggleShowDropDown = () => {
@@ -32,10 +32,11 @@ import {
           </TouchableOpacity>
           <Text style={styles.centeredText}>{date}</Text>
         </View>
-        {showDropDown && <XDropDown  
+        {showDropDown && <XDropDown
         handleClear = {handleClear}
         handleRefresh = {handleRefresh}
-        handleUpdate = {handleUpdate}/>}
+        handleUpdate = {handleUpdate}
+        handleChart = {handleChart}/>}
       </View>
     );
   };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "react-native-document-picker": "^9.3.1",
     "react-native-fs": "^2.20.0",
     "react-native-push-notification": "^8.1.1",
-    "react-native-sqlite-storage": "^6.0.1"
+    "react-native-sqlite-storage": "^6.0.1",
+    "three": "^0.164.0",
+    "react-native-threejs": "^0.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- gather frequency of math words via `getMathWordCounts`
- add `WordFreq3DChart` component using `react-native-threejs`
- allow opening chart from header menu
- integrate chart into the main App screen
- document feature and update dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684798575278832abeebe00c273c40f5