### PR TITLE
Use stable ids for check entries

### DIFF
--- a/Form_Components/Checks_Tasks.js
+++ b/Form_Components/Checks_Tasks.js
@@ -28,75 +28,72 @@ const styles = StyleSheet.create({
   },
 });
 
-function checkboxChange(previous, index){
-  const updatedItems = previous;
-      // Update the specific item at the given index
-      if (updatedItems[index].status == '' && updatedItems[index].status != 'Future'){
-        updatedItems[index].status = 'Completed';}
-      else if(updatedItems[index].status != 'Future'){
-        updatedItems[index].status = '';
-      }
-      updatedItems[index].updateTime = Date.now();
-      return updatedItems;
+const generateUniqueId = () => `${Date.now().toString()}-${Math.random().toString(16).slice(2)}`;
+
+function checkboxChange(previous, id){
+  const timestamp = Date.now();
+  return previous.map(item => {
+    if(item.id !== id){
+      return item;
+    }
+    if (item.status !== 'Future'){
+      const newStatus = item.status == '' ? 'Completed' : '';
+      return {...item, status: newStatus, updateTime: timestamp};
+    }
+    return {...item, updateTime: timestamp};
+  });
 }
 
-function futureCheckChange(previous, index){
-  const updatedItems = previous;
-  // Update the specific item at the given index
-  if (updatedItems[index].status == 'Future'){
-    updatedItems[index].status = '';}
-  else{
-    updatedItems[index].status = 'Future';
-  }
-  updatedItems[index].updateTime = Date.now();
-  return updatedItems;  // Return the updated array
+function futureCheckChange(previous, id){
+  const timestamp = Date.now();
+  return previous.map(item => item.id === id ? {...item, status: item.status === 'Future' ? '' : 'Future', updateTime: timestamp} : item);
 }
 
 function ChecksTasks(props) {
 
   const [showPrevious, setShowPrevious] = useState(false);
 
-  const handleCheckboxChange = (index) => {
+  const handleCheckboxChange = (id) => {
     props.setValue((prevItems) => {
-      return checkboxChange([...prevItems], index);  // Return the updated array
+      return checkboxChange([...prevItems], id);  // Return the updated array
     });
   };
 
-  const handlePreviousCheckboxChange = (index) => {
+  const handlePreviousCheckboxChange = (id) => {
     props.updatePrevious((prevItems) => {
-      return checkboxChange([...prevItems], index);  // Return the updated array
+      return checkboxChange([...prevItems], id);  // Return the updated array
     });
   };
 
-  const handleFutureCheckboxChange = (index) => {
+  const handleFutureCheckboxChange = (id) => {
     props.updateFuture((prevItems) => {
-      return checkboxChange([...prevItems], index);  // Return the updated array
+      return checkboxChange([...prevItems], id);  // Return the updated array
     });
   };
 
-  const handleFuture = (index) =>{ 
+  const handleFuture = (id) =>{
     props.setValue((prevItems) => {
-      return futureCheckChange([...prevItems], index);  // Return the updated array
+      return futureCheckChange([...prevItems], id);  // Return the updated array
     });
 
   }
 
-  const handlePreviousFuture = (index) =>{ 
+  const handlePreviousFuture = (id) =>{
     props.updatePrevious((prevItems) => {
-      return futureCheckChange([...prevItems], index);  // Return the updated array
+      return futureCheckChange([...prevItems], id);  // Return the updated array
     });
 
   }
 
-  const changeFuture = (index) =>{ 
+  const changeFuture = (id) =>{
     props.updateFuture((prevItems) => {
-      return futureCheckChange([...prevItems], index);  // Return the updated array
+      return futureCheckChange([...prevItems], id);  // Return the updated array
     });
 
   }
 
-  const handleShowPrevious = (index) => {
-    setShowPrevious(!showPrevious);
+  const handleShowPrevious = () => {
+    setShowPrevious(prev => !prev);
   };
 
   const deleteTask = (id) => {
@@ -105,14 +102,9 @@ function ChecksTasks(props) {
     props.updateFuture(prev => prev.filter(item => item.id !== id));
   };
 
-  const handleTask = (newValue, index) =>{
+  const handleTask = (newValue, id) =>{
     props.setValue((prevItems) => {
-      // Create a copy of the array
-      const updatedItems = [...prevItems];
-      // Update the specific item at the given index
-      updatedItems[index].task = newValue;
-      updatedItems[index].id = Date.now();
-      return updatedItems;  // Return the updated array
+      return prevItems.map(item => item.id === id ? {...item, task: newValue, updateTime: Date.now()} : item);
     });
   }
 
@@ -120,6 +112,7 @@ function ChecksTasks(props) {
     const tasks = []
     for (let i = 0; i < props.count; i++) {
       const element = {
+        id: generateUniqueId(),
         status:'',
         task:'',
         updateTime: Date.now(),
@@ -139,30 +132,30 @@ function ChecksTasks(props) {
   return(
   <View>
   <Title title = {props.title} />
-  {Array.from(props.value).map((value, index) => (
-    <View style ={styles.checkrow} key={index}>
+  {Array.from(props.value).map((value) => (
+    <View style ={styles.checkrow} key={value.id}>
       <CheckBox
             status={value.status}
-            onChange={() =>handleCheckboxChange(index)}
-            onHold={() => handleFuture(index)}
+            onChange={() =>handleCheckboxChange(value.id)}
+            onHold={() => handleFuture(value.id)}
       />
       <XTextInput
           height = {40}
           flex = {1}
           description={value.task}// Use the setter function passed as a prop
-          setDescription={text => handleTask(text, index)}
+          setDescription={text => handleTask(text, value.id)}
           placeholder = {`Task`}
           />
     </View>
     ))}
   <SubTitle title='Previous' onClick = {handleShowPrevious}/>
-  
-  {showPrevious && (Array.from(props.previousTasks).map((value, index) => (
-    <View style ={styles.checkrow}  key={index}>
+
+  {showPrevious && (Array.from(props.previousTasks).map((value) => (
+    <View style ={styles.checkrow}  key={value.id}>
     <CheckBox
           status={value.status}
-          onChange={() =>handlePreviousCheckboxChange(index)}
-          onHold={() => handlePreviousFuture(index)}
+          onChange={() =>handlePreviousCheckboxChange(value.id)}
+          onHold={() => handlePreviousFuture(value.id)}
     />
     <XTextDisplay
         height={25}
@@ -174,12 +167,12 @@ function ChecksTasks(props) {
     )))}
   <SubTitle title='Future' onClick = {handleShowPrevious}/>
 
-  {showPrevious && (Array.from(props.futureTasks).map((value, index) => (
-    <View style ={styles.checkrow}  key={index}>
+  {showPrevious && (Array.from(props.futureTasks).map((value) => (
+    <View style ={styles.checkrow}  key={value.id}>
     <CheckBox
           status={value.status}
-          onChange={() =>handleFutureCheckboxChange(index)}
-          onHold={() => changeFuture(index)}
+          onChange={() =>handleFutureCheckboxChange(value.id)}
+          onHold={() => changeFuture(value.id)}
     />
     <XTextDisplay
         height={25}

--- a/Form_Components/Checks_Thanks.js
+++ b/Form_Components/Checks_Thanks.js
@@ -37,83 +37,72 @@ const styles = StyleSheet.create({
   },
 });
 
-function checkboxChange(previous, index){
-  const updatedItems = previous;
-  // Update the specific item at the given index
-  if (updatedItems[index].status == '' && updatedItems[index].status != 'Future'){
-    updatedItems[index].status = 'Completed';}
-  else if(updatedItems[index].status != 'Future'){
-    updatedItems[index].status = '';
-  }
-  updatedItems[index].updateTime = Date.now();
-  return updatedItems;
+const generateUniqueId = () => `${Date.now().toString()}-${Math.random().toString(16).slice(2)}`;
+
+function checkboxChange(previous, id){
+  const timestamp = Date.now();
+  return previous.map(item => {
+    if(item.id !== id){
+      return item;
+    }
+    if (item.status !== 'Future'){
+      const newStatus = item.status === '' ? 'Completed' : '';
+      return {...item, status: newStatus, updateTime: timestamp};
+    }
+    return {...item, updateTime: timestamp};
+  });
 }
 
-function futureCheckChange(previous, index){
-  const updatedItems = previous;
-  // Update the specific item at the given index
-  if (updatedItems[index].status == 'Future'){
-    updatedItems[index].status = '';}
-  else{
-    updatedItems[index].status = 'Future';
-  }
-  updatedItems[index].updateTime = Date.now();
-  return updatedItems;  // Return the updated array
+function futureCheckChange(previous, id){
+  const timestamp = Date.now();
+  return previous.map(item => item.id === id ? {...item, status: item.status === 'Future' ? '' : 'Future', updateTime: timestamp} : item);
 }
 
-function propertyChange(previous, index, name, value){
-  const updatedItems = previous;
-  updatedItems[index][name] = value;
-  updatedItems[index].updateTime = Date.now();
-  return updatedItems;  // Return the updated array
+function propertyChange(previous, id, name, value){
+  return previous.map(item => item.id === id ? {...item, [name]: value, updateTime: Date.now()} : item);
 }
 
-async function listChange(previous, index, name, value){
+async function listChange(previous, id, name, value){
   let nameList = [];
-  const updatedItems = previous;
-  updatedItems[index][name] = value;
-  updatedItems[index].updateTime = Date.now();
   try {
     nameList = await getList(`name`, `appreciation_table`, value+ '%');
-    updatedItems[index].names = nameList;
-    //setNames(nameList)
   } catch (error) {
     console.log('failed to find other names with ' + value)
   }
-  return updatedItems;
+  return previous.map(item => item.id === id ? {...item, [name]: value, names: nameList, updateTime: Date.now()} : item);
 }
 
 function ChecksThanks(props) {
 
   const [showPrevious, setShowPrevious] = useState(false);
 
-  const handleCheckboxChange = (index) => {
+  const handleCheckboxChange = (id) => {
     props.setValue((prevItems) => {
-      return checkboxChange([...prevItems], index);  // Return the updated array
+      return checkboxChange([...prevItems], id);  // Return the updated array
     });
   };
 
-  const handlePreviousCheckboxChange = (index) => {
+  const handlePreviousCheckboxChange = (id) => {
     props.updatePrevious((prevItems) => {
-      return checkboxChange([...prevItems], index);  // Return the updated array
+      return checkboxChange([...prevItems], id);  // Return the updated array
     });
   };
 
-  const handlePropertyChange = async (index, name, value) => {
+  const handlePropertyChange = async (id, name, value) => {
     if(name == `name` && value != null){
-      const updatedItems = await listChange([...props.value], index, name, value);
+      const updatedItems = await listChange([...props.value], id, name, value);
       props.setValue(updatedItems);
       return;
     }
     else{
     props.setValue((prevItems) => {
-      return propertyChange([...prevItems], index, name, value);  // Return the updated array
+      return propertyChange([...prevItems], id, name, value);  // Return the updated array
     });
     }
   };
 
   const handleShowPrevious = () => {
-    setShowPrevious(!showPrevious);
+    setShowPrevious(prev => !prev);
   };
 
   const deleteThanks = (id) => {
@@ -125,10 +114,12 @@ function ChecksThanks(props) {
     const tasks = []
     for (let i = 0; i < props.count; i++) {
       const element = {
+        id: generateUniqueId(),
         status:'',
         thanks:'',
         name:'',
         names:[],
+        updateTime: Date.now(),
       };
       tasks.push(element)
     }
@@ -144,17 +135,17 @@ function ChecksThanks(props) {
   return(
   <View>
   <Title title = {props.title} />
-  {Array.from(props.value).map((value, index) => (
-    <View style ={styles.checkrow} key={index}>
+  {Array.from(props.value).map((value) => (
+    <View style ={styles.checkrow} key={value.id}>
       <CheckBox
             status={value.status}
-            onChange={() => handleCheckboxChange(index)}
+            onChange={() => handleCheckboxChange(value.id)}
       />
       <XTextInput
           height = {40}
           width = '30%'
           description={value.name}
-          setDescription={text => handlePropertyChange(index,'name',text)}
+          setDescription={text => handlePropertyChange(value.id,'name',text)}
           placeholder = {`Name`}
           itemList = {value.names}
           />
@@ -163,17 +154,17 @@ function ChecksThanks(props) {
           width = '50%'
           flex = {1}
           description={value.thanks}
-          setDescription={text => handlePropertyChange(index,'thanks',text)}
+          setDescription={text => handlePropertyChange(value.id,'thanks',text)}
           placeholder = {`Thank You..`}
           />
     </View>
     ))}
   <SubTitle title='Previous' onClick = {handleShowPrevious}/>
-  {showPrevious && (Array.from(props.previousThanks).map((value, index) => (
-    <View style ={styles.checkrow} key={index}>
+  {showPrevious && (Array.from(props.previousThanks).map((value) => (
+    <View style ={styles.checkrow} key={value.id}>
       <CheckBox
             status={value.status}
-            onChange={() => handlePreviousCheckboxChange(index)}
+            onChange={() => handlePreviousCheckboxChange(value.id)}
       />
       <XTextDisplay
         height={25}

--- a/Storage_Components/Store_Form.js
+++ b/Storage_Components/Store_Form.js
@@ -539,7 +539,9 @@ function softDeleteItem(tableName, id){
     tx.executeSql(
       `UPDATE ${tableName} SET deleted = 1 WHERE id = ?`,
       [id],
-      () => {},
+      () => {
+        console.log('Deleted '+ id)
+      },
       error => { console.log('Error deleting item', error); }
     );
   });


### PR DESCRIPTION
## Summary
- switch checklist task and thanks components to use unique item ids instead of array indexes for keys and updates
- generate ids for new entries and update state transitions to work immutably with id-based lookups
- refresh toggle handlers and placeholders to ensure timestamps stay current when statuses change

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f175a6228832ab44761fca8f0836a)