### PR TITLE
Fix night journal notification scheduling by using unique notification IDs

### DIFF
--- a/Notify_Components/Notify.js
+++ b/Notify_Components/Notify.js
@@ -6,9 +6,9 @@ import PushNotification from 'react-native-push-notification';
 import BackgroundTimer from 'react-native-background-timer';
 
 
-const sendTimedNotification = (title, message, time) => {
+const sendTimedNotification = (id, title, message, time) => {
   PushNotification.localNotificationSchedule({
-    id: '001',
+    id,
     channelId: "xdays-channel",  // The channel ID
     title: title,
     message: message,
@@ -117,7 +117,7 @@ function NotifyDay({date, prevDays, setPrevDays, taskTime, nightTime}){
     //console.log(`Found the following length ${tasks.length}`);
     if (tasks.length != 0 && !hasScheduledTasks.current) {
       const dayTaskNotification = formatTasksNotification(tasks);
-      sendTimedNotification('xDAYS - Day Tasks Reminder', dayTaskNotification, timeUntil2_30PM );
+      sendTimedNotification('day-tasks', 'xDAYS - Day Tasks Reminder', dayTaskNotification, timeUntil2_30PM );
     
       const taskTimer = calculateCountdownUntilTarget(hours, min);
       
@@ -140,7 +140,7 @@ function NotifyDay({date, prevDays, setPrevDays, taskTime, nightTime}){
 
       const nightNotification = `Time to journal ${prevDay.prevDayCount>1 && `its been ${prevDay.prevDayCount} days`}`
 
-      sendTimedNotification('xDAYS - Journal Reminder', nightNotification, nightTimer);
+      sendTimedNotification('night-journal', 'xDAYS - Journal Reminder', nightNotification, nightTimer);
       hasScheduledPrevDay.current = true;
     }
 


### PR DESCRIPTION
### Motivation
- The night journal notification was being overwritten or not fired because scheduled notifications used the same static ID.  
- The app was showing `dayTaskNotification` but not `nightNotification`, indicating ID collision when scheduling.  
- Ensure each scheduled notification is uniquely identifiable so both day and night reminders persist.  

### Description
- Changed `sendTimedNotification` signature to accept an `id` parameter and pass it to `PushNotification.localNotificationSchedule`.  
- Replaced the hardcoded `'001'` ID with the provided `id` in `Notify_Components/Notify.js`.  
- Use distinct IDs when scheduling: `'day-tasks'` for the day reminder and `'night-journal'` for the night journal reminder.  

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694beb3717b0832a9180cf79bc8307f4)